### PR TITLE
Add final modifiers

### DIFF
--- a/lib/src/option/option.dart
+++ b/lib/src/option/option.dart
@@ -396,7 +396,7 @@ sealed class Option<T> {
 ///   print(bar);
 /// }
 /// ```
-class Some<T> extends Option<T> {
+final class Some<T> extends Option<T> {
 	final T value;
 
 	const Some(this.value);
@@ -416,7 +416,7 @@ class Some<T> extends Option<T> {
 ///   print('No value!');
 /// }
 /// ```
-class None<T> extends Option<T> {
+final class None<T> extends Option<T> {
 	const None();
 }
 

--- a/lib/src/option/option_error.dart
+++ b/lib/src/option/option_error.dart
@@ -1,7 +1,7 @@
 part of option;
 
 /// Represents an error thrown by a mishandled [Option] type value.
-class OptionError extends Error {
+final class OptionError extends Error {
 	/// The message this `OptionError` was created with.
 	final dynamic message;
 

--- a/lib/src/result/result.dart
+++ b/lib/src/result/result.dart
@@ -414,7 +414,7 @@ sealed class Result<T, E> {
 ///   print('Ok value: $bar');
 /// }
 /// ```
-class Ok<T, E> extends Result<T, E> {
+final class Ok<T, E> extends Result<T, E> {
 	final T value;
 
 	const Ok(this.value);
@@ -434,7 +434,7 @@ class Ok<T, E> extends Result<T, E> {
 ///   print('Error value: $err');
 /// }
 /// ```
-class Err<T, E> extends Result<T, E> {
+final class Err<T, E> extends Result<T, E> {
 	final E value;
 
 	const Err(this.value);

--- a/lib/src/result/result_error.dart
+++ b/lib/src/result/result_error.dart
@@ -1,7 +1,7 @@
 part of result;
 
 /// Represents an error thrown by a mishandled [Result] type value.
-class ResultError<T, E> extends Error {
+final class ResultError<T, E> extends Error {
 	/// The message this `ResultError` was created with.
 	final dynamic message;
 


### PR DESCRIPTION
First of all, great package!

I don't think it makes sense to extend the classes that are affected by this PR. It would make more sense to create custom sealed classes, for example, for `Err` types, e.g.:

```dart
sealed class CustomError {
  // ..
}

final class Possibility1 extends CustomError {
  // ..
}

final class Possibility2 extends CustomError {
  // ..
}

Result <int, CustomError> myFn() {
  // ..
}
```

Also, this greatly improves pattern matching. Consider the following non-final class:

```dart
class ExampleClass {}
```

Before this PR the IDE does not highlight potentially unmatchable types, due to Dart's implicit interfaces. For example, there could be a class that extends `ExampleClass` and implements `Option`:

![Screenshot from 2023-11-19 13-11-15](https://github.com/zajrik/option_result/assets/55398763/9e023b3a-531d-4d25-acb0-beb342d6ecd4)

After this PR:

![Screenshot from 2023-11-19 13-12-41](https://github.com/zajrik/option_result/assets/55398763/2edea06f-6217-48af-ba41-04cfaf809567)
